### PR TITLE
Added Sleigh bells to the instruments

### DIFF
--- a/mamar-web/src/app/instruments.ts
+++ b/mamar-web/src/app/instruments.ts
@@ -227,6 +227,8 @@ export const categories = [
             { bank: 0x30, patch: 0xA4, name: "Reverse Cymbal" },
 
             { bank: 0x30, patch: 0xE4, name: "Woodblock" },
+
+            { bank: 0x30, patch: 0xF8, name: "Sleigh Bells" },
         ],
     },
     {


### PR DESCRIPTION
I've noticed that there is a sleigh bell instrument not in the list at patch 0XF8, or 248

Was unable to verify if it worked as I was unable to get mamar to build at all, but there should be no reason why it doesn't work.